### PR TITLE
Use visual-line-mode in *portacle-help* buffer

### DIFF
--- a/portacle-help.el
+++ b/portacle-help.el
@@ -3,6 +3,7 @@
 (with-current-buffer (get-buffer-create "*portacle-help*")
   (insert-file-contents (portacle-path "config/help.txt"))
   (read-only-mode)
+  (visual-line-mode)
   (emacs-lock-mode 'kill))
 
 (defun portacle-help ()


### PR DESCRIPTION
This eases reading of the long-lines buffer considerably, 
as by default emacs will break lines at the middle of any word.

* portacle-help.el (top): Use visual-line-mode