### PR TITLE
Add support for SLY

### DIFF
--- a/portacle-slime.el
+++ b/portacle-slime.el
@@ -60,9 +60,12 @@
                (funcall (read-from-string "swank:start-server")
                         ,(slime-to-lisp-filename port-filename))))))
 
-;; Activate Slime after init
-(add-hook 'emacs-startup-hook
-          (lambda ()
-            (slime-setup portacle-slime-contribs)
-            (when window-system
-              (slime))))
+(slime-setup portacle-slime-contribs)
+
+;; Make sure we don't clash with SLY
+(advice-add 'slime :before
+            (lambda (&rest ignored)
+              (remove-hook 'lisp-mode-hook 'sly-editing-mode t)
+              (add-hook 'lisp-mode-hook 'slime-lisp-mode-hook t))
+            '((name . portacle-advice-before-slime)))
+

--- a/portacle-sly.el
+++ b/portacle-sly.el
@@ -1,0 +1,28 @@
+(provide 'portacle-sly)
+
+(remove-hook 'lisp-mode-hook 'slime-lisp-mode-hook)
+
+(ensure-installed 'sly)
+(require 'sly)
+
+(setq sly-auto-select-connection 'always)
+(setq sly-kill-without-query-p t)
+(setq sly-description-autofocus t) 
+(setq sly-inhibit-pipelining nil)
+(setq sly-load-failed-fasl 'always)
+
+;; XXX: Work around a bug in SLY whereby installing/compiling it as
+;; above fails to correctly set version (not very problematic for
+;; Portacle, which always ensures matching versions anyway)
+(setq sly-ignore-protocol-mismatches t)
+
+;; Make sure SLY knows about our SBCL
+(setq sly-lisp-implementations
+      `((sbcl (,(portacle-bin-path "sbcl")))))
+
+;; Make sure we don't clash with SLIME
+(advice-add 'sly :before
+            (lambda (&rest ignored)
+              (remove-hook 'lisp-mode-hook 'slime-lisp-mode-hook)
+              (add-hook 'lisp-mode-hook 'sly-editing-mode t))
+            '((name . portacle-advice-before-sly)))

--- a/portacle-user.el
+++ b/portacle-user.el
@@ -1,5 +1,6 @@
 (provide 'portacle-user)
 
-(setq custom-file (portacle-path "config/user.el"))
-(when (file-exists-p (portacle-path "config/user.el"))
-  (load (portacle-path "config/user.el")))
+(setq custom-file (portacle-path "config/user.el")
+      user-init-file custom-file)
+(when (file-exists-p user-init-file)
+  (load user-init-file))


### PR DESCRIPTION
This change introduces a new customizable variable, `portacle-ide`,
that lets the user choose the IDE started when Portacle launches. The
default value is a function that prompts the user to choose between
SLIME or SLY and then asks the user if he'd like to keep that choice
for future sessions. SLIME is the first and default choice.

In any case, even if the user chooses SLIME, SLY is loaded alongside
it. This is quite fine as long as the `lisp-mode-hook` doesn't contain
both `slime-major-mode-hook` and `sly-editing-mode` simultaneously,
which would cause keybinding conflicts in Lisp source buffers. To
avoid this, very light advising of `sly` and `slime` functions is
used.

The variable `portacle-ide` is customizable, should the user change
her/his mind later on. However, to enable saving of customization
variables to actually work in Portacle's Emacs, which is launched with
custom-file but without user-init-file, we set the latter to the
former. This change is in portacle-user.el.

* portacle-slime.el (slime): Advise slime to watch out for SLY
major-mode hook.
(portacle-slime-contribs): Setup contribs when loading init.

* portacle-sly.el: New file. Same as portacle-slime, but simpler.

* portacle-user.el (file-exists-p): Set user-init-file to
something non-nil so that saving customization actually works.

* portacle.el (portacle-sly): Require it.
(portacle-let-user-choose-ide): New function.
(defgroup portacle): New customization group.
(defcustom portacle-ide): New custom variable.
(portacle--start-ide-maybe): New helper.
(emacs-startup-hook): Add it here.