### PR TITLE
sly-company isn't really needed

### DIFF
--- a/portacle-company.el
+++ b/portacle-company.el
@@ -1,6 +1,6 @@
 (provide 'portacle-company)
 
-(ensure-installed 'company 'company-quickhelp 'slime-company 'sly-company)
+(ensure-installed 'company 'company-quickhelp 'slime-company)
 
 (require 'company)
 
@@ -9,8 +9,6 @@
 
 (global-company-mode)
 (push 'slime-company portacle-slime-contribs)
-(add-hook 'sly-mode-hook 'sly-company-mode)
-(add-to-list 'company-backends 'sly-company)
 
 (define-key company-active-map (kbd "<up>") 'company-select-previous)
 (define-key company-active-map (kbd "<down>") 'company-select-next)


### PR DESCRIPTION
Because company's built-in company-capf wrapper works much better.

* portacle-company.el (ensure-installed, add-hook sly-mode-hool)
(add-to-list company-backends): No more sly-company.