### PR TITLE
Better looking company tooltip annotations

### DIFF
--- a/portacle-company.el
+++ b/portacle-company.el
@@ -5,7 +5,8 @@
 (require 'company)
 
 (company-quickhelp-mode 1)
-(setq company-quickhelp-delay 0.7)
+(setq company-quickhelp-delay 0.7
+      company-tooltip-align-annotations t)
 
 (global-company-mode)
 (push 'slime-company portacle-slime-contribs)


### PR DESCRIPTION
Should improve both SLY and SLIME's company-mode interoperation.

* portacle-company.el (company-tooltip-align-annotations): Set to
t.