### PR TITLE
Cleanup portacle-help.el's compilation warnings

### DIFF
--- a/portacle.el
+++ b/portacle.el
@@ -65,6 +65,8 @@
 (require 'portacle-help)
 (require 'portacle-user)
 
+(portacle-create-help-buffer)
+
 (defun portacle--startup ()
   "Start Portacle's IDE iff there is a window system."
   (when (window-system)


### PR DESCRIPTION
Not only did compilation fail, but loading it failed, because
`loop' and `first' were used before `cl' was required (which shouldn't
be required anyway).  New code compiles cleanly and requires `cl-lib'

The top level call was converted to a portacle-create-help-buffer
function.  This was preventing revaluation of the buffer.

Feature is provided at end of the file, as is customary.

* portacle-help.el (cl-lib, portacle-keys, portacle-config):
Require it.
(portacle-path): Forward declare it.
(portacle--read-inner-list, portacle--scratch-contents): use
cl-loop.
(portacle--interpret-scratch-expr): use cl-first and cl-rest.
(portacle-create-help-buffer): New helper.

* portacle.el: Call `portacle-create-help-buffer'.