### PR TITLE
emacs-slime-nav is kinda useless in emacs 25 which has xref

### DIFF
--- a/portacle-elisp.el
+++ b/portacle-elisp.el
@@ -1,6 +1,3 @@
 (provide 'portacle-elisp)
 
-(ensure-installed 'elisp-slime-nav 'paredit)
-
-(require 'elisp-slime-nav)
-(add-hook 'emacs-lisp-mode-hook 'elisp-slime-nav-mode)
+(ensure-installed 'paredit)


### PR DESCRIPTION
* portacle-elisp.el (emacs-slime-nav): Don't require this