### PR TITLE
Use electric-pair-mode in the SLY repl

### DIFF
--- a/portacle-sly.el
+++ b/portacle-sly.el
@@ -29,6 +29,9 @@
 (add-to-list 'minor-mode-alist '(sly-mode
                                  (" " sly--mode-line-format " ")))
 
+;; Don't turn on paredit in REPL, but at least use electric-pair-mode
+(add-hook 'sly-mrepl-mode-hook 'electric-pair-local-mode)
+
 ;; Make sure we don't clash with SLIME when starting
 (require 'portacle-slime) ; for portacle--resolve-ide-conflict
 (advice-add 'sly :before


### PR DESCRIPTION
The SLY REPL doesn't have paren-matching by default.
    
I like electric-pair-mode because it's a less intrusive and
authoritarian version of paredit-mode, and it's built-into Emacs, by
me :)


* portacle-sly.el (sly-mrepl-mode-hook): Use electric-pair-local-mode