### PR TITLE
Portacle update

### DIFF
--- a/portacle-update.el
+++ b/portacle-update.el
@@ -43,7 +43,7 @@
       (insert "  --> Updating client via QL\n")
       (slime-eval '(ql:update-client :prompt cl:nil))
       (insert "  --> Updating packages via ELPA\n")
-      (poratcle-update-packages)
+      (portacle-update-packages)
       (insert "===> All done\n")
       (insert "\n Please restart Portacle for the changes to take full effect.\n")
       (insert "\n Press q to close this buffer."))))

--- a/portacle-update.el
+++ b/portacle-update.el
@@ -13,7 +13,7 @@
   (interactive)
   (package-refresh-contents)
   (cl-flet ((get-version (name where)
-              (let ((pkg (second (assq name where))))
+              (let ((pkg (cl-second (assq name where))))
                 (when pkg
                   (package-desc-version pkg)))))
     (save-window-excursion


### PR DESCRIPTION
Fixing `poratcle-update-packages` typo revealed that `second` should be replaced by `cl-second` in `portacle-update-packages`.