### PR TITLE
portacle-update: don't try to delete used packages

### DIFF
--- a/portacle-update.el
+++ b/portacle-update.el
@@ -23,7 +23,8 @@
                 do (when (and in-archive
                               (version-list-< (get-version name package-alist) in-archive))
                      (package-install name)
-                     (push package-desc to-delete)))
+                     (unless (package--used-elsewhere-p package-desc)
+                       (push package-desc to-delete))))
        (mapcar #'package-delete to-delete)))))
 
 (defun portacle-update ()


### PR DESCRIPTION
portacle-update was triggering errors like
```
package-delete:
Package ‘async-20180527.1030’ is used by ‘with-editor’ as dependency, not deleting
```
causing the update to be interrupted.
Fixed by checking if the package is used elsewhere before trying to delete it.