### PR TITLE
Stop making the scratch buffer read-only

### DIFF
--- a/portacle-help.el
+++ b/portacle-help.el
@@ -160,10 +160,7 @@
           (apply #'insert (portacle-markup-file (portacle-path "config/scratch.txt")))
           (setq portacle--help-region
                 (cons start
-                      (point-marker)))
-          (add-text-properties (car portacle--help-region)
-                               (cdr portacle--help-region)
-                               '(read-only t)))))))
+                      (point-marker))))))))
 
 (defun portacle--create-help-buffer ()
   "Ensure a *portacle-help* buffer is created and has good tips."


### PR DESCRIPTION
Fixes portacle/portacle#100

I decided to just completely remove the read-only property, since for a scratch buffer I don't think it makes sense to have even a part of it be read-only.