### PR TITLE
Remove all browse-url-browser-function definitions

### DIFF
--- a/portacle-general.el
+++ b/portacle-general.el
@@ -33,15 +33,6 @@
 (setq version-control t)
 (setq vc-follow-symlinks t)
 
-(setq browse-url-browser-function
-      (lambda (url &optional new-tab)
-        (os-case (gnu/linux
-                  (call-process "xdg-open" nil 0 nil url))
-                 (darwin
-                  (call-process "open" nil 0 nil url))
-                 (windows-nt
-                  (call-process "cmd" nil 0 nil "/c" (concat "start " url))))))
-
 (defun delete-this-buffer-and-file ()
   "Removes file connected to current buffer and kills buffer."
   (interactive)

--- a/portacle-help.el
+++ b/portacle-help.el
@@ -1,4 +1,5 @@
 ;; -*- lexical-binding: t -*-
+(require 'browse-url)
 (require 'cl-lib)
 (require 'portacle-keys) ; define-portacle-key
 (require 'portacle-config)

--- a/portacle-window.el
+++ b/portacle-window.el
@@ -1,4 +1,3 @@
-(require 'browse-url)
 (require 'cl-lib)
 (require 'portacle-package)
 (require 'portacle-keys)
@@ -12,8 +11,6 @@
 (setq pop-up-frame-function (lambda () (split-window-right)))
 (setq split-height-threshold 1400)
 (setq split-width-threshold 1500)
-(setq browse-url-browser-function 'browse-url-generic)
-(setq browse-url-generic-program (or (getenv "BROWSER") "xdg-open"))
 (setq ring-bell-function 'ignore)
 
 (defun portacle--setup-frame ()


### PR DESCRIPTION
The definition in portacle-general.el was portable, but the definition
in portacle-window.el was loaded later and would overwrite it with a
non-portable version.

The custom implementation in portacle-general.el, however, was less
portable than the default implementation, so both definitions are either
unnecessary or unwanted.

Fixes portacle/portacle#96