### PR TITLE
Set show-paren-delay before show-paren-mode

### DIFF
--- a/portacle-general.el
+++ b/portacle-general.el
@@ -9,6 +9,7 @@
 
 (doom-modeline-init)
 (ido-mode 1)
+(setq show-paren-delay 0) ; must be set before show-paren-mode
 (show-paren-mode 1)
 (electric-indent-mode 1)
 (semantic-mode 1)
@@ -19,7 +20,6 @@
 
 (setq-default indent-tabs-mode nil)
 (setq-default buffer-file-coding-system 'utf-8-unix)
-(setq show-paren-delay 0)
 (setq ido-enable-flex-matching t)
 (setq ido-everywhere t)
 (setq enable-local-variables :all)


### PR DESCRIPTION
Prior to this change, `(setq show-paren-delay 0)` has no effect because
it is called after `(show-paren-mode 1)`. When we place the point after
a closing parenthesis, there is a small delay (a default delay of 125
milliseconds) before the opening parenthesis gets highlighted.

The `show-paren-delay` variable must be set before `show-paren-mode` is
enabled for the variable to take effect. This is documented in Emacs
help (`C-h o show-paren-delay`) as follows:

> If you change this without using customize while ‘show-paren-mode’ is
> active, you must toggle the mode off and on again for this to take
> effect.

This commit fixes this issue by ensuring that `show-paren-delay` is set
before enabling `show-paren-mode`.