### PR TITLE
Enable ido-everywhere with function call

### DIFF
--- a/portacle-general.el
+++ b/portacle-general.el
@@ -9,6 +9,7 @@
 
 (doom-modeline-init)
 (ido-mode 1)
+(ido-everywhere 1)
 (setq show-paren-delay 0) ; must be set before show-paren-mode
 (show-paren-mode 1)
 (electric-indent-mode 1)
@@ -21,7 +22,6 @@
 (setq-default indent-tabs-mode nil)
 (setq-default buffer-file-coding-system 'utf-8-unix)
 (setq ido-enable-flex-matching t)
-(setq ido-everywhere t)
 (setq enable-local-variables :all)
 (setq backup-by-copying t)
 (setq backup-directory-alist `((,tramp-file-name-regexp . nil)


### PR DESCRIPTION
Prior to this change, `(setq ido-everywhere t)` has no effect. For
example, if we type `M-x ediff-files RET`, Ido mode does not work in
the minibuffer. The documentation for `ido-everywhere` accessible via
`C-h v ido-everywhere RET` has the following note regarding this
behaviour:

    Setting this variable directly does not take effect;
    either customize it (see the info node ‘Easy Customization’)
    or call the function ‘ido-everywhere’.

This change fixes this issue by calling the `ido-everywhere` function.
With this fix, Ido mode now works with `M-x ediff-files RET`.